### PR TITLE
Fix for file picker in OSX

### DIFF
--- a/demo_app/app/scripts/directives/explorer.js
+++ b/demo_app/app/scripts/directives/explorer.js
@@ -83,7 +83,7 @@ window.maidsafeDemo.directive('explorer', ['$rootScope', '$timeout', 'safeApiFac
         var dialog = require('remote').dialog;
         dialog.showOpenDialog({
           title: 'Select Directory for upload',
-          properties: isFile ? [] : ['openDirectory']
+          properties: isFile ? ['openFile'] : ['openDirectory']
         }, function(selection) {
           if (!selection || selection.length === 0) {
             return;


### PR DESCRIPTION
When the properties array is empty, OSX treats it as DirectoryPicker. Had to specify the 'openFile' property

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_examples/42)
<!-- Reviewable:end -->
