### PR TITLE
feat/pass_args_to_package: pass arch argument while packaging

### DIFF
--- a/demo_app/README.md
+++ b/demo_app/README.md
@@ -47,28 +47,7 @@ npm run package
 ```
 this will generate the package files in the `app_dist` folder
 
+Additional `arch` argument can be passed to the `package` command. If this argument is not specified,
+the current nodejs platform architecture will be used. Accepted values are `x86` and `x64`.
 
-# Making a release
-
-To make ready for distribution installer use command:
-```
-npm run release
-```
-It will start the packaging process for operating system you are running this command on. Ready for distribution file will be outputted to `releases` directory.
-
-You can create Windows installer only when running on Windows, the same is true for Linux and OSX. So to generate all three installers you need all three operating systems.
-
-## Mac only
-
-#### App signing
-
-The Mac release supports [code signing](https://developer.apple.com/library/mac/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html). To sign the `.app` in the release image, include the certificate ID in the command as so,
-```
-npm run release -- --sign A123456789
-```
-
-## Windows only
-
-#### Installer
-
-The installer is built using [NSIS](http://nsis.sourceforge.net). You have to install NSIS version 3.0, and add its folder to PATH in Environment Variables.
+Example usage `npm run package -- --arch=x64`

--- a/demo_app/tasks/package.js
+++ b/demo_app/tasks/package.js
@@ -20,6 +20,15 @@ if (process.platform === 'win32') {
   packagerPath += '.cmd';
 }
 
+var arch = utils.getArch();
+if (arch !== 'x86' && arch !== 'x64') {
+  return console.log('Packaging failed. Invalid architecture specified');
+}
+
+console.log('Packaging application for %s architecture', arch);
+
+var electronArch = (arch === 'x86') ? 'ia32' : arch;
+
 // Notes for OSX
 // - app-category-type is from https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8
 // - app-bundle-id and helper-bundle-id can only contain alpha numeric characters or '-' or '.'
@@ -52,8 +61,8 @@ var packageForOs = {
 var config = packageForOs[utils.os()];
 
 var appVersion = packageConfig.version;
-var packageFolderName = util.format('%s-%s-%s', config.packageName, config.platform, os.arch());
-var packageNameWithVersion = util.format('%s-v%s-%s-%s', config.packageName, appVersion, config.platform, os.arch());
+var packageFolderName = util.format('%s-%s-%s', config.packageName, config.platform, electronArch);
+var packageNameWithVersion = util.format('%s-v%s-%s-%s', config.packageName, appVersion, config.platform, arch);
 
 var onPackageCompleted = function() {
   var packagePath = pathUtil.resolve('.', OUT_FOLDER, packageFolderName);
@@ -89,7 +98,7 @@ var packageApp = function() {
   }
   return gulp.src('./')
       .pipe(exec(packagerPath + ' build \"' + config.packageName + '\" --icon=' + config.icon + ' --platform=' + config.platform +
-          ' --asar --asar-unpack=' + config.unpack + ' --out=' + OUT_FOLDER + ' --arch=' + os.arch() + ' --version=' + electronVersion +
+          ' --asar --asar-unpack=' + config.unpack + ' --out=' + OUT_FOLDER + ' --arch=' + electronArch + ' --version=' + electronVersion +
           ' --app-version=' + appVersion + ' --app-copyright=\"' + packageConfig.copyright + '\" --prune --overwrite ' + config.packagePreference))
       .pipe(exec.reporter(reportOptions));
 };

--- a/demo_app/tasks/utils.js
+++ b/demo_app/tasks/utils.js
@@ -16,6 +16,10 @@ module.exports.os = function() {
   return 'unsupported';
 };
 
+module.exports.getArch = function() {
+  return argv.arch || os.arch();
+};
+
 module.exports.replace = function(str, patterns) {
   Object.keys(patterns).forEach(function(pattern) {
     var matcher = new RegExp('{{' + pattern + '}}', 'g');


### PR DESCRIPTION
pass x86 or x64 argument while packaging. If no argument is passed the os.Arch() is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_examples/114)
<!-- Reviewable:end -->
