### PR TITLE
Remove stray '2'

### DIFF
--- a/demo_app/app/scripts/directives/explorer.js
+++ b/demo_app/app/scripts/directives/explorer.js
@@ -17,7 +17,7 @@ window.maidsafeDemo.directive('explorer', [ '$rootScope', '$state', '$timeout', 
           displayName: 'Public folder',
           name: 'public',
           description: 'Public data is content that you wish to share with other ' +
-          'users, such as websites. Public data is not encrypted and therefore not 2' +
+          'users, such as websites. Public data is not encrypted and therefore not ' +
           'suitable for information which you wish to remain private.'
         },
         {


### PR DESCRIPTION
I just noticed this when running the demo app, and it looks a lot like a typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_examples/119)
<!-- Reviewable:end -->
