### PR TITLE
fix safe_app_nodejs path in README

### DIFF
--- a/web_hosting_manager/README.md
+++ b/web_hosting_manager/README.md
@@ -17,7 +17,7 @@ Install with [yarn](https://github.com/yarnpkg/yarn) for faster and safer instal
 yarn install
 ```
 
-Manually build `safe_app_nodejs` dependency from `app/node_modules/safe-app`
+Manually build [safe_app_nodejs](https://github.com/maidsafe/safe_app_nodejs) dependency from `app/node_modules/safe-app`
 
 ## Run
 

--- a/web_hosting_manager/README.md
+++ b/web_hosting_manager/README.md
@@ -17,7 +17,7 @@ Install with [yarn](https://github.com/yarnpkg/yarn) for faster and safer instal
 yarn install
 ```
 
-Manually build `safe_app_nodejs` dependency from `app/node_modules/safe_app_nodejs`
+Manually build `safe_app_nodejs` dependency from `app/node_modules/safe-app`
 
 ## Run
 


### PR DESCRIPTION
The path should `app/node_modules/safe-app` instead of `app/node_modules/safe_app_nodejs`.