### PR TITLE
remove /index.html for safe:// website links

### DIFF
--- a/web_hosting_manager/app/components/Home.js
+++ b/web_hosting_manager/app/components/Home.js
@@ -245,7 +245,7 @@ export default class Auth extends Component {
         return (
           <Row key={ `serviceName-${i}`}>
             <Col md={{ span: 8 }} lg={{ span: 8 }}>
-              <a href={`safe://${serviceName}.${publicId}/index.html`}>{serviceName}</a>
+              <a href={`safe://${serviceName}.${publicId}`}>{serviceName}</a>
             </Col>
             <Col md={{ span: 10 }} lg={{ span: 10 }}>
               <Link


### PR DESCRIPTION
Now that [this issue](https://github.com/maidsafe/safe_browser/issues/73) has been fixed, I think it should be fine to remove "/index.html" from the safe:// website links in Web Hosting Manager.

So the only difference would be that when someone clicks on a safe:// website link in Web Hosting Manager, it opens safe://mywebsite instead of safe://mywebsite/index.html in the SAFE Browser.

It's a very minor difference, but I think this is what most users would expect 🙂 See for example [this feedback](https://safenetforum.org/t/maidsafe-dev-update-august-3-2017-test-18/15261/46?u=frabrunelle) from @davidpbrown:

> too trivial to log… the link from the web host manager back to browser seems to prefer the /index.html rather than not having that.