### PR TITLE
fix/dir-upload: MAID-2212 Setup root dir when uploading dirs.

### DIFF
--- a/web_hosting_manager/app/lib/Uploader.js
+++ b/web_hosting_manager/app/lib/Uploader.js
@@ -35,6 +35,8 @@ export default class Uploader {
   start() {
     this[status].uploading = true;
     const stat = fs.statSync(this[localPath]);
+    const baseDir = path.basename( this[localPath] );
+
     const callback = (error, taskStatus) => {
       if (error) {
         this[status].errored = true;
@@ -59,7 +61,7 @@ export default class Uploader {
       this[status].total = Helper.getDirectoryStats(this[localPath]);
       this[status].completed = new Helper.DirStats();
       this[taskQueue] = Helper.generateUploadTaskQueue(this[localPath],
-        this[networkPath], callback);
+        this[networkPath], callback, baseDir );
       this[taskQueue].run();
     } else {
       const fileName = path.basename(this[localPath]);

--- a/web_hosting_manager/app/lib/utils.js
+++ b/web_hosting_manager/app/lib/utils.js
@@ -107,23 +107,36 @@ export const getDirectoryStats = (localPath) => {
   return stats;
 };
 
-export const generateUploadTaskQueue = (localPath, networkPath, callback) => {
+export const generateUploadTaskQueue = (localPath, networkPath, callback, baseDir ) => {
   let stat;
   let tempPath;
   const taskQueue = callback instanceof TaskQueue ? callback : new TaskQueue(callback);
   let nextDir = null;
   const contents = fs.readdirSync(localPath);
+
+  let updatedLocation = networkPath;
+
+  if( baseDir )
+  {
+    updatedLocation = `${networkPath}/${baseDir}`;
+  }
+
+  tempPath = `${localPath}`;
+
   for (let i = 0; i < contents.length; i += 1) {
+
     if (!contents[i]) {
       return;
     }
+
     tempPath = `${localPath}/${contents[i]}`;
     stat = fs.statSync(tempPath);
+
     if (stat.isDirectory()) {
-      nextDir = `${networkPath}/${contents[i]}`;
+      nextDir = `${updatedLocation}/${contents[i]}`;
       generateUploadTaskQueue(tempPath, nextDir, taskQueue);
     } else {
-      taskQueue.add(new Task.FileUploadTask(tempPath, `${networkPath}/${contents[i]}`));
+      taskQueue.add(new Task.FileUploadTask(tempPath, `${updatedLocation}/${contents[i]}`));
     }
   }
   return taskQueue;


### PR DESCRIPTION
Adds am optional `baseDir` param to `generateUploadTaskQueue` to trigger appending a directory (and used when uploading one).