### PR TITLE
MAID-2304: allows users to upload multiple file or folders

### DIFF
--- a/web_hosting_manager/app/components/FileExplorer.js
+++ b/web_hosting_manager/app/components/FileExplorer.js
@@ -60,12 +60,14 @@ export default class FileExplorer extends Component {
   open(onlyFile) {
     remote.dialog.showOpenDialog({
       title: I18n.t(onlyFile ? 'label.selectFile' : 'label.selectDirectory'),
-      properties: onlyFile ? ['openFile'] : ['openDirectory']
+      properties: onlyFile ? ['openFile', 'multiSelections'] : ['openDirectory', 'multiSelections']
     }, (selection) => {
       if (!selection || selection.length === 0) {
         return;
       }
-      this.props.upload(selection[0], this.currentPath);
+      selection.forEach((filePath) => {
+        this.props.upload(filePath, this.currentPath);
+      });
     });
   }
 


### PR DESCRIPTION
```
Note: On Windows and Linux an open dialog can not be both a file selector and a directory selector, so if you set properties to ['openFile', 'openDirectory'] on these platforms, a directory selector will be shown.
```
https://electron.atom.io/docs/api/dialog/