### PR TITLE
fix/allow mock version to be built, run or packaged

### DIFF
--- a/web_hosting_manager/package.json
+++ b/web_hosting_manager/package.json
@@ -20,7 +20,7 @@
     "package-all": "npm run build && build -mwl",
     "package-linux": "npm run build && build --linux",
     "package-win": "npm run build && build --win --x64",
-    "postinstall": "concurrently \"npm run flow-typed\" \"npm run build-dll\" \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\"",
+    "postinstall": "concurrently \"npm run flow-typed\" \"npm run build-dll\" \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\" && yarn rebuild",
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=production electron ./app/",
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./app/main.dev",


### PR DESCRIPTION
Tested on Windows.
PR allows one to once more be able to build mock version of WHM.
Tested both running mock and packaging, as well as seamlessly switching to `NODE_ENV=prod` to build for network.